### PR TITLE
Simplify to just use docker system prune

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// This is setup as a separate job named 'spotify-docker-gc'
+// This is setup as a separate job named 'docker-gc'
 // which matches the job specified in the kickoff script
 pipeline {
     agent { node { label "$TARGET_NODE" } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,9 @@
 pipeline {
     agent { node { label "$TARGET_NODE" } }
     stages {
-        stage('Pull latest image') {
+        stage('Prune') {
             steps {
-                sh 'docker pull spotify/docker-gc'
-            }
-        }
-        stage('Run docker-gc') {
-            steps {
-                sh 'docker run --rm -v /var/run/docker.sock:/var/run/docker.sock spotify/docker-gc'
+                sh 'docker system prune --all --force'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Coordinates running Docker garbage collection on all Jenkins slaves
 Kind of unfortunately, this requires that two jobs within your Jenkins cluster be setup.
 
 1. A coordination job (named whatever you'd like) which uses a "Pipeline script from SCM" and a script path of `all_agent_kickoff.groovy`
-* A `spotify-docker-gc` job with a script path of `Jenkinsfile`
+* A `docker-gc` job with a script path of `Jenkinsfile`

--- a/all_agent_kickoff.groovy
+++ b/all_agent_kickoff.groovy
@@ -1,4 +1,4 @@
-// The script triggers 'spotify-docker-gc' on every node.
+// The script triggers 'docker-gc' on every node.
 // It uses Node and Label Parameter plugin to pass the job name to the payload job.
 // The code will require approval of several Jenkins classes in the Script Security mode
 def branches = [:]
@@ -10,7 +10,7 @@ for (int i=0; i<names.size(); ++i) {
   branches["node_" + nodeName] = {
     node(nodeName) {
       echo "Triggering on " + nodeName
-      build job: 'spotify-docker-gc', parameters: [
+      build job: 'docker-gc', parameters: [
         new org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterValue("TARGET_NODE", "description", nodeName)
       ]
     }


### PR DESCRIPTION
In more recent versions of Docker the `docker system` toolchain provides us with the `prune` command to "remove unused data."

I think going with this simplifies the garbage collection, allowing us to use build-in commands  instead of relying on an image when the disk may be so full the additional image can't be pulled or created.

__Prune options used:__

```
Options:
  -a, --all             Remove all unused images not just dangling ones
  -f, --force           Do not prompt for confirmation
```